### PR TITLE
Rework trap and utilities distribution rules

### DIFF
--- a/apworld/openttd_exp/__init__.py
+++ b/apworld/openttd_exp/__init__.py
@@ -1,6 +1,6 @@
 """
 OpenTTD Archipelago World (Experimental)
-Version: exp-5.0
+Version: exp-5.1
 Supports: OpenTTD 15.2
 
 A full Archipelago integration for OpenTTD.
@@ -1004,47 +1004,18 @@ class OpenTTDWorld(World):
 
 
     def pre_fill(self) -> None:
-        """Manually distribute ALL progression, trap, and utility items.
+        """Manually distribute ALL progression.
 
-        Fill order:
-          1. Traps + utility → missions / ruins / demigods (NEVER shop)
-          2. Progression items → distributed by fixed percentages:
              - Missions 40% (filled easy→medium→hard→extreme)
              - Shop 40%
              - Ruins 10%  (if enabled, else redistributed)
              - Demigods 10% (if enabled, else redistributed)
-          3. AP fill handles remaining useful/filler → all locations freely
 
         This guarantees:
-          - Traps NEVER appear in the shop
           - Progression is evenly split across pools
           - Easy missions get progression first (early finds)
         """
-        # ── Step 1: Lock traps + utility into non-shop locations ──────────
-        trap_utility_names = frozenset(TRAP_ITEMS) | frozenset(UTILITY_ITEMS)
 
-        trap_utility_items = [item for item in self.multiworld.itempool
-                               if item.player == self.player
-                               and item.name in trap_utility_names]
-        for item in trap_utility_items:
-            self.multiworld.itempool.remove(item)
-
-        if trap_utility_items:
-            non_shop_locs: list = []
-            for rname in ("mission_easy", "mission_medium", "mission_hard",
-                          "mission_extreme", "ruin", "demigod", "star"):
-                region = self.multiworld.get_region(rname, self.player)
-                non_shop_locs.extend(loc for loc in region.locations if not loc.item)
-
-            self.multiworld.random.shuffle(non_shop_locs)
-            self.multiworld.random.shuffle(trap_utility_items)
-
-            for item in trap_utility_items:
-                if non_shop_locs:
-                    loc = non_shop_locs.pop()
-                    loc.place_locked_item(item)
-
-        # ── Step 2: Distribute progression items by fixed percentages ─────
         # Each pool gets a fixed % of progression items.
         # Missions are split per difficulty tier for granular control.
         _, _, ruin_count, demigod_count, star_count = self._compute_pool_size()

--- a/apworld/openttd_exp/rules.py
+++ b/apworld/openttd_exp/rules.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Dict, Callable
 from BaseClasses import MultiWorld, CollectionState
+from worlds.generic.Rules import add_item_rule
 from .items import (
     ALL_VEHICLES, IRON_HORSE_ENGINES,
     MILITARY_ITEMS_AIRCRAFT, SHARK_SHIPS, HOVER_VEHICLES,
@@ -12,6 +13,7 @@ from .items import (
     NARROW_GAUGE_TRACK_ITEMS, METRO_TRACK_ITEMS, VACTUBE_TRACK_ITEMS,
     # Tram direction items
     TRAM_DIRECTION_ITEMS,
+    TRAP_ITEMS, UTILITY_ITEMS
 )
 
 if TYPE_CHECKING:
@@ -398,9 +400,13 @@ def set_rules(world: "OpenTTDWorld") -> None:
 
     # ------------------------------------------------------------------
     # Shop: require cargo capability — player needs to earn money
+    # We don't want our own traps or utilities in shops either, since they're both
+    # "never buy" / "always buy", respectively, that makes them uninteresting here.
     # ------------------------------------------------------------------
+    TRAP_UTILITY_NAMES = frozenset(TRAP_ITEMS) | frozenset(UTILITY_ITEMS)
     for loc in multiworld.get_region("shop", player).locations:
         loc.access_rule = lambda state: eff_has_cargo_capability(state, player)
+        add_item_rule(loc, lambda item: item.player != player or item.name not in TRAP_UTILITY_NAMES)
 
     # ------------------------------------------------------------------
     # Ruins: require cargo capability — ruins need cargo deliveries


### PR DESCRIPTION
We can let the generator handle the distribution of our own traps and our utilities by enforcing item rules instead of placing those items ourselves in our non-shop locations. Now other worlds can send them to us and that's way more fun!